### PR TITLE
fix: fixed get_code_frame.rs

### DIFF
--- a/src/compiler/utils/error.rs
+++ b/src/compiler/utils/error.rs
@@ -64,7 +64,7 @@ impl CompileError {
             column: start.column,
         });
         let frame = start
-            .map(|start| get_code_frame(props.source.to_string(), start.line - 1, start.column));
+            .map(|start| get_code_frame(props.source.to_string(), (start.line - 1) as isize, start.column as isize));
 
         Self {
             code: props.code.to_string(),
@@ -102,7 +102,7 @@ mod tests {
             end: Location { line: 1, column: 1 },
             pos: 0,
             filename: "filename".to_string(),
-            frame: "source\n    ^".to_string(),
+            frame: "1: source\n    ^".to_string(),
             message: "error".to_string(),
         };
 

--- a/src/compiler/utils/error.rs
+++ b/src/compiler/utils/error.rs
@@ -102,7 +102,7 @@ mod tests {
             end: Location { line: 1, column: 1 },
             pos: 0,
             filename: "filename".to_string(),
-            frame: "1: source\n    ^".to_string(),
+            frame: "1: source\n   ^".to_string(),
             message: "error".to_string(),
         };
 

--- a/src/compiler/utils/get_code_frame.rs
+++ b/src/compiler/utils/get_code_frame.rs
@@ -10,19 +10,20 @@ fn tabs_to_spaces(str: &str) -> String {
     .to_string()
 }
 
-pub fn get_code_frame(source: String, line: usize, column: usize) -> String {
+pub fn get_code_frame(source: String, line: isize, column: isize) -> String {
     let lines = source.split("\n").collect::<Vec<&str>>();
-    let (frame_start, frame_end) = (max(0, line - 2), min(line - 3, lines.len()));
+    let (frame_start, frame_end) = (max(0, line - 2), min(line + 3, lines.len() as isize));
+    let frame_start = frame_start as usize;
+    let frame_end = frame_end as usize;
     let digits = format!("{}", frame_end + 1).len();
-    let joined = &lines[frame_start..frame_end]
+    let joined = &lines[frame_start as usize..frame_end as usize]
         .into_iter()
         .enumerate()
         .map(|t| {
             let line_num = format!("{:digits$}", t.0 + frame_start + 1);
 
-            if frame_start + t.0 == line {
-                let indicator =
-                    " ".repeat(digits + 2 + tabs_to_spaces(&t.1[0..column]).len()) + "^";
+            if frame_start + t.0 == line as usize {
+                let indicator = " ".repeat(digits + 2 + tabs_to_spaces(&t.1[0..column.try_into().unwrap()]).len()) + "^";
                 return format!("{line_num}: {}\n{indicator}", tabs_to_spaces(*t.1));
             }
 

--- a/src/compiler/utils/get_code_frame.rs
+++ b/src/compiler/utils/get_code_frame.rs
@@ -30,7 +30,7 @@ pub fn get_code_frame(source: String, line: isize, column: isize) -> String {
             return format!("{line_num}: {}", tabs_to_spaces(*t.1));
         })
         .collect::<Vec<String>>()
-        .join(" ");
+        .join("\n");
 
     joined.to_owned()
 }


### PR DESCRIPTION
Fixed the `attempt to subtract with overflow` error. This error was caused by trying to subtract the `line` or `column` parameters by a bigger number. In order to fix this I changed the type of the `line` and `column` parameters to `isize`.  