### PR TITLE
feat:  Fully implemented text.rs, Added the TmpNode Trait

### DIFF
--- a/src/compiler/interfaces.rs
+++ b/src/compiler/interfaces.rs
@@ -30,7 +30,7 @@ impl BaseNode {
 
 impl TmpNode for BaseNode {
     fn get_base_node(&mut self) -> &mut BaseNode {
-        &mut self
+        self
     }
 }
 
@@ -435,7 +435,7 @@ impl TemplateNode {
         }
     }
 
-    pub fn unwrap(&self) -> &dyn TmpNode {
+    pub fn unwrap(&mut self) -> &mut dyn TmpNode {
         match self {
             TemplateNode::Text(Text) => Text,
             TemplateNode::ConstTag(ConstTag) => ConstTag,

--- a/src/compiler/interfaces.rs
+++ b/src/compiler/interfaces.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::any::Any;
 
 use magic_string::SourceMap;
 use strum_macros::Display;
@@ -27,6 +28,12 @@ impl BaseNode {
     }
 }
 
+impl TmpNode for BaseNode {
+    fn get_base_node(&mut self) -> &mut BaseNode {
+        &mut self
+    }
+}
+
 #[derive(Clone)]
 pub struct Fragment {
     pub base_node: BaseNode,
@@ -38,6 +45,12 @@ impl Fragment {
             base_node: BaseNode::new("Fragment".to_string()),
         }
     }
+}
+
+
+//This trait allows for different concreate types when matching a TemplateNode enum
+pub trait TmpNode {
+    fn get_base_node(&mut self) -> &mut BaseNode;
 }
 
 #[derive(Clone)]
@@ -52,6 +65,12 @@ impl Text {
             base_node: BaseNode::new("Text".to_string()),
             data,
         }
+    }
+}
+
+impl TmpNode for Text {
+    fn get_base_node(&mut self) -> &mut BaseNode {
+        &mut self.base_node
     }
 }
 
@@ -77,6 +96,12 @@ impl MustacheTag {
     }
 }
 
+impl TmpNode for MustacheTag {
+    fn get_base_node(&mut self) -> &mut BaseNode {
+        &mut self.base_node
+    }
+}
+
 #[derive(Clone)]
 pub struct Comment {
     pub base_node: BaseNode,
@@ -91,6 +116,12 @@ impl Comment {
             data,
             ignores,
         }
+    }
+}
+
+impl TmpNode for Comment {
+    fn get_base_node(&mut self) -> &mut BaseNode {
+        &mut self.base_node
     }
 }
 
@@ -109,6 +140,12 @@ impl ConstTag {
     }
 }
 
+impl TmpNode for ConstTag {
+    fn get_base_node(&mut self) -> &mut BaseNode {
+        &mut self.base_node
+    }
+}
+
 #[derive(Clone)]
 pub struct DebugTag {
     pub base_node: BaseNode,
@@ -123,6 +160,13 @@ impl DebugTag {
         }
     }
 }
+
+impl TmpNode for DebugTag {
+    fn get_base_node(&mut self) -> &mut BaseNode {
+        &mut self.base_node
+    }
+}
+
 
 #[derive(Display)]
 pub enum DirectiveType {
@@ -149,6 +193,12 @@ impl BaseDirective {
             base_node: BaseNode::new(directive_type.to_string()),
             name,
         }
+    }
+}
+
+impl TmpNode for BaseDirective {
+    fn get_base_node(&mut self) -> &mut BaseNode {
+        &mut self.base_node
     }
 }
 
@@ -217,6 +267,12 @@ impl Element {
     }
 }
 
+impl TmpNode for Element {
+    fn get_base_node(&mut self) -> &mut BaseNode {
+        &mut self.base_node
+    } 
+}
+
 #[derive(Clone)]
 pub struct Attribute {
     pub base_node: BaseNode,
@@ -234,6 +290,12 @@ impl Attribute {
     }
 }
 
+impl TmpNode for Attribute {
+    fn get_base_node(&mut self) -> &mut BaseNode {
+        &mut self.base_node
+    }
+}
+
 #[derive(Clone)]
 pub struct SpreadAttribute {
     pub base_node: BaseNode,
@@ -246,6 +308,12 @@ impl SpreadAttribute {
             base_node: BaseNode::new("Spread".to_string()),
             expression,
         }
+    }
+}
+
+impl TmpNode for SpreadAttribute {
+    fn get_base_node(&mut self) -> &mut BaseNode {
+        &mut self.base_node
     }
 }
 
@@ -271,11 +339,33 @@ impl Transition {
     }
 }
 
+impl TmpNode for Transition {
+    fn get_base_node(&mut self) -> &mut BaseNode {
+        &mut self.base_expression_directive.base_directive.base_node
+    }
+}
+
 #[derive(Clone)]
 pub enum Directive {
     BaseDirective(BaseDirective),
     BaseExpressionDirective(BaseExpressionDirective),
     Transition(Transition),
+}
+
+impl TmpNode for Directive {
+    fn get_base_node(&mut self) -> &mut BaseNode {
+        match self {
+            Directive::BaseDirective(bd) => {
+                bd.get_base_node()
+            },
+            Directive::BaseExpressionDirective(bed) => {
+                bed.base_directive.get_base_node()
+            },
+            Directive::Transition(t ) => {
+                t.get_base_node()
+            }
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -344,6 +434,22 @@ impl TemplateNode {
             TemplateNode::Comment(c) => c.base_node.node_type.clone(),
         }
     }
+
+    pub fn unwrap(&self) -> &dyn TmpNode {
+        match self {
+            TemplateNode::Text(Text) => Text,
+            TemplateNode::ConstTag(ConstTag) => ConstTag,
+            TemplateNode::DebugTag(DebugTag) => DebugTag,
+            TemplateNode::MustacheTag(MustacheTag) => MustacheTag,
+            TemplateNode::BaseNode(BaseNode) => BaseNode,
+            TemplateNode::Element(Element) => Element,
+            TemplateNode::Attribute(Attribute) => Attribute,
+            TemplateNode::SpreadAttribute(SpreadAttribute) => SpreadAttribute,
+            TemplateNode::Directive(Directive) => Directive,
+            TemplateNode::Transition(Transition) => Transition,
+            TemplateNode::Comment(Comment) => Comment,
+        }
+    }   
 }
 
 // We don't have interfaces in Rust

--- a/src/compiler/parse/index.rs
+++ b/src/compiler/parse/index.rs
@@ -37,7 +37,7 @@ pub enum StateReturn {
 }
 
 //A function pointer for state
-pub type ParserState = fn(Parser) -> StateReturn;
+pub type ParserState = fn(&mut Parser) -> StateReturn;
 
 impl Parser {
     fn new(template: String, options: ParserOptions) -> Parser {
@@ -65,7 +65,7 @@ impl Parser {
             last_auto_closed_tag: None,
         };
 
-        parser.stack.push(TemplateNode::BaseNode(parser.html.base_node));
+        parser.stack.push(TemplateNode::BaseNode(parser.html.base_node.clone()));
 
         // Html is a Fragment but gets pushed to
         // parser.stack which is a Vec<TemplateNode> ??
@@ -75,7 +75,9 @@ impl Parser {
         // defined in src/compiler/parse/state/fragment.ts
         // let state: ParserState = fragment;
 
-        let state: ParserState = fragment
+
+        
+        // let state: ParserState = fragment
 
         // while parser.index < parser.template.len() {
         //     state = state(parser) || fragment;
@@ -110,18 +112,19 @@ impl Parser {
         // 	});
         // }
 
-        if let Some(children) = &parser.html.base_node.children {
-            if children.len() > 0 {
-                // TODO: impl BaseNodeTrait to get values from common base node?
-                //let start = children[0].start;
-            }
-        }
+        // if let Some(children) = &parser.html.base_node.children {
+        //     if children.len() > 0 {
+        //         // TODO: impl BaseNodeTrait to get values from common base node?
+        //         //let start = children[0].start;
+        //     }
+        // }
 
         parser
     }
 
-    pub fn current(&self) -> &TemplateNode {
-        &self.stack[self.stack.len() - 1]
+    pub fn current(&mut self) -> &mut TemplateNode {
+        let length = self.stack.len() - 1;
+        &mut self.stack[length]
     }
 
     pub fn error(&self, code: &str, message: &str) {

--- a/src/compiler/parse/state/fragment.rs
+++ b/src/compiler/parse/state/fragment.rs
@@ -4,11 +4,13 @@ use crate::compiler::parse::state::{mustache, tag, text::text};
 
 pub fn fragment(parser: &mut Parser) -> StateReturn  {
     if parser.match_str("<") {
-        return StateReturn::Ok(tag)
+        //TODO implement tag.rs
+        // return StateReturn::Ok(tag)
     }
 
     if parser.match_str("{") {
-        return StateReturn::Ok(mustache)
+        //TODO implement mustache.rs
+        // return StateReturn::Ok(mustache)
     }
 
     return StateReturn::Ok(text)

--- a/src/compiler/parse/state/fragment.rs
+++ b/src/compiler/parse/state/fragment.rs
@@ -1,13 +1,15 @@
 use crate::compiler::parse::index::Parser;
+use crate::compiler::parse::index::StateReturn;
+use crate::compiler::parse::state::{mustache, tag, text::text};
 
-pub fn fragment(parser: Parser) {
+pub fn fragment(parser: &mut Parser) -> StateReturn  {
     if parser.match_str("<") {
-        //return tag;
+        return StateReturn::Ok(tag)
     }
 
     if parser.match_str("{") {
-        //return mustache;
+        return StateReturn::Ok(mustache)
     }
 
-    //text
+    return StateReturn::Ok(text)
 }

--- a/src/compiler/parse/state/text.rs
+++ b/src/compiler/parse/state/text.rs
@@ -1,8 +1,8 @@
-use crate::compiler::interfaces::{BaseNode, Text};
-use crate::compiler::parse::index::Parser;
+use crate::compiler::interfaces::{BaseNode, Text, TemplateNode};
+use crate::compiler::parse::index::{Parser, StateReturn};
 use crate::compiler::parse::utils::decode_character_references;
 
-pub fn text(parser: Parser) {
+pub fn text(parser: Parser) -> StateReturn {
     let start = parser.index;
     let mut data = String::new();
 
@@ -22,5 +22,10 @@ pub fn text(parser: Parser) {
         data: decode_character_references(data),
     };
 
-    //parser.current().children.push(node);
+    let tempNode = parser.current().unwrap();
+    let base_node = tempNode.get_base_node();
+
+    base_node.children.unwrap().push(TemplateNode::Text((node)));
+
+    StateReturn::None
 }

--- a/src/compiler/parse/state/text.rs
+++ b/src/compiler/parse/state/text.rs
@@ -2,7 +2,7 @@ use crate::compiler::interfaces::{BaseNode, Text, TemplateNode};
 use crate::compiler::parse::index::{Parser, StateReturn};
 use crate::compiler::parse::utils::decode_character_references;
 
-pub fn text(parser: Parser) -> StateReturn {
+pub fn text(parser: &mut Parser) -> StateReturn {
     let start = parser.index;
     let mut data = String::new();
 
@@ -25,7 +25,7 @@ pub fn text(parser: Parser) -> StateReturn {
     let tempNode = parser.current().unwrap();
     let base_node = tempNode.get_base_node();
 
-    base_node.children.unwrap().push(TemplateNode::Text((node)));
+    base_node.children.as_mut().unwrap().push(TemplateNode::Text((node)));
 
     StateReturn::None
 }


### PR DESCRIPTION
I implemented text.rs and added a `TmpNode` trait. The `TmpNode` trait is implemented on struct used in the `TemplateNode` enum. This trait allows for an opaque value to be used when matching `TemplateNode`. Also `TemplateNode` now has an unwrap method that returns the trait object `&mut dyn TmpNode`. Another change I made is adding the ParserState type which corresponds to [ParserState svelte](https://github.com/sveltejs/svelte/blob/master/src/compiler/parse/index.ts#L10).