### PR TITLE
feat: Implemented the rest of the parser constructor

### DIFF
--- a/rustle/src/compiler/interfaces.rs
+++ b/rustle/src/compiler/interfaces.rs
@@ -8,8 +8,8 @@ use super::node::Node;
 
 #[derive(Clone, Debug)]
 pub struct BaseNode {
-    pub start: usize,
-    pub end: usize,
+    pub start: Option<usize>,
+    pub end: Option<usize>,
     pub node_type: String,
     pub children: Vec<TemplateNode>,
     pub prop_name: HashMap<String, TemplateNode>,
@@ -21,8 +21,8 @@ pub struct BaseNode {
 impl BaseNode {
     fn new(node_type: String) -> BaseNode {
         BaseNode {
-            start: 0,
-            end: 0,
+            start: Some(0),
+            end: Some(0),
             node_type,
             children: Vec::new(),
             prop_name: HashMap::new(),

--- a/rustle/src/compiler/parse/state/fragment.rs
+++ b/rustle/src/compiler/parse/state/fragment.rs
@@ -13,5 +13,5 @@ pub fn fragment(parser: &mut Parser) -> StateReturn {
         // return StateReturn::Ok(mustache)
     }
 
-    return text(parser);
+    return StateReturn::Ok(text);
 }

--- a/rustle/src/compiler/parse/state/mod.rs
+++ b/rustle/src/compiler/parse/state/mod.rs
@@ -2,3 +2,5 @@ mod fragment;
 mod mustache;
 mod tag;
 mod text;
+
+pub use fragment::fragment;

--- a/rustle/src/compiler/parse/state/mustache.rs
+++ b/rustle/src/compiler/parse/state/mustache.rs
@@ -71,8 +71,8 @@ mod tests {
     fn test_trim_whitespace_trim_before() {
         let mut sample = TemplateNode::Text(Text {
             base_node: BaseNode {
-                start: 0,
-                end: 0,
+                start: Some(0),
+                end: Some(0),
                 node_type: "Text".to_string(),
                 children: vec![TemplateNode::Text(Text::new("   Hello ".to_string()))],
                 prop_name: Default::default(),
@@ -92,8 +92,8 @@ mod tests {
     fn test_trim_whitespace_trim_after() {
         let mut sample = TemplateNode::Text(Text {
             base_node: BaseNode {
-                start: 0,
-                end: 0,
+                start: Some(0),
+                end: Some(0),
                 node_type: "Text".to_string(),
                 children: vec![TemplateNode::Text(Text::new("   Hello   ".to_string()))],
                 prop_name: Default::default(),
@@ -113,8 +113,8 @@ mod tests {
     fn test_trim_whitespace_trim_both() {
         let mut sample = TemplateNode::Text(Text {
             base_node: BaseNode {
-                start: 0,
-                end: 0,
+                start: Some(0),
+                end: Some(0),
                 node_type: "Text".to_string(),
                 children: vec![TemplateNode::Text(Text::new("    Hello    ".to_string()))],
                 prop_name: Default::default(),
@@ -134,8 +134,8 @@ mod tests {
     fn test_trim_whitespace_shift_first_child() {
         let mut sample = TemplateNode::Text(Text {
             base_node: BaseNode {
-                start: 0,
-                end: 0,
+                start: Some(0),
+                end: Some(0),
                 node_type: "Text".to_string(),
                 children: vec![
                     TemplateNode::Text(Text::new("    ".to_string())),
@@ -158,8 +158,8 @@ mod tests {
     fn test_trim_whitespace_pop_last_child() {
         let mut sample = TemplateNode::Text(Text {
             base_node: BaseNode {
-                start: 0,
-                end: 0,
+                start: Some(0),
+                end: Some(0),
                 node_type: "Text".to_string(),
                 children: vec![
                     TemplateNode::Text(Text::new("Test".to_string())),
@@ -182,8 +182,8 @@ mod tests {
     fn test_trim_whitespace_else_node_shift_child() {
         let else_node = TemplateNode::Text(Text {
             base_node: BaseNode {
-                start: 0,
-                end: 0,
+                start: Some(0),
+                end: Some(0),
                 node_type: "Text".to_string(),
                 children: vec![
                     TemplateNode::Text(Text::new("  ".to_string())),
@@ -197,8 +197,8 @@ mod tests {
             data: " Hello ".to_string(),
         });
         let base_node = BaseNode {
-            start: 0,
-            end: 0,
+            start: Some(0),
+            end: Some(0) ,
             node_type: "MustacheTag".to_string(),
             children: vec![
                 TemplateNode::Text(Text::new("  ".to_string())),
@@ -224,8 +224,8 @@ mod tests {
     fn test_trim_whitespace_else_node_pop_child() {
         let else_node = TemplateNode::Text(Text {
             base_node: BaseNode {
-                start: 0,
-                end: 0,
+                start: Some(0),
+                end: Some(0),
                 node_type: "Text".to_string(),
                 children: vec![
                     TemplateNode::Text(Text::new("222".to_string())),
@@ -239,8 +239,8 @@ mod tests {
             data: " Hello ".to_string(),
         });
         let base_node = BaseNode {
-            start: 0,
-            end: 0,
+            start: Some(0),
+            end: Some(0),
             node_type: "MustacheTag".to_string(),
             children: vec![
                 TemplateNode::Text(Text::new("111".to_string())),
@@ -266,8 +266,8 @@ mod tests {
     fn test_trim_whitespace_elseif_node_shift_child() {
         let else_node = TemplateNode::Text(Text {
             base_node: BaseNode {
-                start: 0,
-                end: 0,
+                start: Some(0),
+                end: Some(0),
                 node_type: "Text".to_string(),
                 children: vec![
                     TemplateNode::Text(Text::new("   ".to_string())),
@@ -281,8 +281,8 @@ mod tests {
             data: " Hello ".to_string(),
         });
         let base_node = BaseNode {
-            start: 0,
-            end: 0,
+            start: Some(0),
+            end: Some(0),
             node_type: "MustacheTag".to_string(),
             children: vec![
                 TemplateNode::Text(Text::new("   ".to_string())),
@@ -308,8 +308,8 @@ mod tests {
     fn test_trim_whitespace_elseif_node_pop_child() {
         let else_node = TemplateNode::Text(Text {
             base_node: BaseNode {
-                start: 0,
-                end: 0,
+                start: Some(0),
+                end: Some(0),
                 node_type: "Text".to_string(),
                 children: vec![
                     TemplateNode::Text(Text::new("222".to_string())),
@@ -323,8 +323,8 @@ mod tests {
             data: " Hello ".to_string(),
         });
         let base_node = BaseNode {
-            start: 0,
-            end: 0,
+            start: Some(0),
+            end: Some(0),
             node_type: "MustacheTag".to_string(),
             children: vec![
                 TemplateNode::Text(Text::new("111".to_string())),

--- a/rustle/src/compiler/parse/state/tag.rs
+++ b/rustle/src/compiler/parse/state/tag.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use crate::compiler::parse::index::{Parser, StateReturn};
 
 use lazy_static::lazy_static;
 use regex::Regex;
@@ -23,3 +24,8 @@ pub const VALID_META_TAGS: [&'static str; 4] = [
     "svelte:fragment",
     "svelte:element",
 ];
+
+
+pub fn tag(parser: &mut Parser) -> StateReturn {
+    todo!()
+}

--- a/rustle/src/compiler/parse/state/text.rs
+++ b/rustle/src/compiler/parse/state/text.rs
@@ -13,8 +13,8 @@ pub fn text(parser: &mut Parser) -> StateReturn {
 
     let node: Text = Text {
         base_node: BaseNode {
-            start,
-            end: parser.index,
+            start: Some(start),
+            end: Some(parser.index),
             node_type: "Text".to_string(),
             children: Vec::new(),
             prop_name: HashMap::new(),


### PR DESCRIPTION
I implemented the rest of the parser constructor and changed the `start `and `end `fields on the `BaseNode `struct to `Option<usize>`. The reason for this is some parts of the program set these fields to null which the Option enum provides an alternative.